### PR TITLE
Syncing more than two maps.

### DIFF
--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -1,9 +1,10 @@
 /*
- * Extends L.Map to synchronize two maps
+ * Extends L.Map to synchronize the interaction on one map to one or more other maps.
  */
 
 L.Map = L.Map.extend({
     sync: function (map) {
+        var originalMap = this;
         this._syncMaps = this._syncMaps || [];
 
         this._syncMaps.push(L.extend(map, {
@@ -33,27 +34,25 @@ L.Map = L.Map.extend({
                 }
                 return L.Map.prototype._onResize.call(this, evt);
             }
-        });
+        }));
 
-
-        var self = this;
-        this.on('zoomend', function() {
-            this._syncMaps.forEach(function (toSync) {
-                toSync.setView(self.getCenter(), self.getZoom(), {reset: false}, true);
+        originalMap.on('zoomend', function() {
+            originalMap._syncMaps.forEach(function (toSync) {
+                toSync.setView(originalMap.getCenter(), originalMap.getZoom(), {reset: false}, true);
             });
         }, this);
 
 
-        this.dragging._draggable._updatePosition = function () {
+        originalMap.dragging._draggable._updatePosition = function () {
             L.Draggable.prototype._updatePosition.call(this);
-            var that = this;
-            self._syncMaps.forEach(function (toSync) {
-                L.DomUtil.setPosition(toSync.dragging._draggable._element, that._newPos);
+            var self = this;
+            originalMap._syncMaps.forEach(function (toSync) {
+                L.DomUtil.setPosition(toSync.dragging._draggable._element, self._newPos);
                 toSync.fire('move');
             });
         };
 
-        return this;
+        return originalMap;
     }
 });
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,25 @@ Leaflet.Sync
 Synchronized view of two maps.
 
 <a href="http://blog.thematicmapping.org/2013/06/creating-synchronized-view-of-two-maps.html">More information</a>
+
+Usage
+-----
+
+## Two maps.
+With two map objects, `mapA` and `mapB`, call `mapA.sync(mapB)` to sync interactions on `mapA` with `mapB`.
+
+In order to make the other direction work, you should make another call: `mapB.sync(mapA)`
+
+
+## More than two maps
+Just make more calls to `map.sync()`, with different map objects. Interaction will be synced to all of them. If you want the actions to be synced vice-versa, you should synchronise all directions.
+
+```JavaScript
+// synchronize three maps
+mapA.sync(mapB);
+mapA.sync(mapC);
+mapB.sync(mapA);
+mapB.sync(mapC);
+mapC.sync(mapA);
+mapC.sync(mapB);
+```

--- a/example-multiple.html
+++ b/example-multiple.html
@@ -67,6 +67,15 @@
     map.sync(mapA);
     map.sync(mapB);
 
+
+    // If you want interaction with mapA|B to be synchronized on map,
+    // add other links as well.
+    // mapA.sync(map);
+    // mapA.sync(mapB);
+
+    // mapB.sync(map);
+    // mapB.sync(mapA);
+
     </script>
 </body>
 </html>


### PR DESCRIPTION
This allows synchronization of more than two maps, by keeping an array of maps to be synced and update each element of the array after interaction.
- added an example
- usage instructions in README.md
