### PR TITLE
Fixes for zoomend + moveend, jshint

### DIFF
--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -52,17 +52,9 @@
                 var self = this;
                 originalMap._syncMaps.forEach(function (toSync) {
                     L.DomUtil.setPosition(toSync.dragging._draggable._element, self._newPos);
-                    toSync.fire('move');
+                    toSync.fire('moveend');
                 });
             };
-
-            if (!originalMap.hasEventListeners('moveend')) {
-                originalMap.on('moveend', function () {
-                    originalMap._syncMaps.forEach(function (toSync) {
-                        toSync.fire('moveend');
-                    });
-                });
-            }
 
             return originalMap;
         }


### PR DESCRIPTION
- The `zoomend` listener was attached to `originalMap` every time new sync relation is added, but it's only needed once, causing `Uncaught TypeError: Cannot read property 'x' of undefined`. ref leaflet-extras/leaflet-providers#72
- Paths were not updated in synced maps after dragging the map.
- jshiting
