### PR TITLE
Added min zoom check before setView

### DIFF
--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -86,10 +86,15 @@
 
             originalMap.on('zoomend', function () {
                 originalMap._syncMaps.forEach(function (toSync) {
-                    toSync.setView(originalMap.getCenter(), originalMap.getZoom(), {
-                        animate: false,
-                        reset: false
-                    });
+                    if (originalMap.getZoom() <= toSync.getMinZoom()) {
+                        originalMap.setZoom(toSync.getZoom());
+                        toSync.panTo(originalMap.getCenter());
+                    } else {
+                        toSync.setView(originalMap.getCenter(), originalMap.getZoom(), {
+                            animate: false,
+                            reset: false
+                        });
+                    }
                 });
             }, this);
 


### PR DESCRIPTION
Another need that I felt was about when we have layers with different zoom level. So if the zoom level of the original map is more than the min zoom, it goes out of sync. One map zooms and the other stays.
I had this fix for our project to stop zooming for the original and keep it to that zoom level.
I am still thinking about unittest part of it but thought to open up the pull request so we can discuss the need of it or maybe improve the change.
