### PR TITLE
fix: avoid flicker on zoomend

### DIFF
--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -5,7 +5,8 @@
 (function () {
     var NO_ANIMATION = {
         animate: false,
-        reset: true
+        reset: true,
+        disableViewprereset: true
     };
 
     // Helper function to compute the offset easily
@@ -130,7 +131,19 @@
                                 zoom, options, true);
                         });
                     }
-                    return L.Map.prototype.setView.call(this, center, zoom, options);
+                    if (options && options.disableViewprereset) {
+                        // The event viewpreresets does an invalidateAll,
+                        // that reloads all the tiles.
+                        // That causes an annoying flicker.
+                        var viewpreresets = this._events.viewprereset;
+                        this._events.viewprereset = [];
+                    }
+                    var ret = L.Map.prototype.setView.call(this, center, zoom, options);
+                    if (options && options.disableViewprereset) {
+                        // restore viewpreresets event to its previous values
+                        this._events.viewprereset = viewpreresets;
+                    }
+                    return ret;
                 },
 
                 panBy: function (offset, options, sync) {

--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -131,11 +131,12 @@
                                 zoom, options, true);
                         });
                     }
+                    var viewpreresets = [];
                     if (options && options.disableViewprereset) {
                         // The event viewpreresets does an invalidateAll,
                         // that reloads all the tiles.
                         // That causes an annoying flicker.
-                        var viewpreresets = this._events.viewprereset;
+                        viewpreresets = this._events.viewprereset;
                         this._events.viewprereset = [];
                     }
                     var ret = L.Map.prototype.setView.call(this, center, zoom, options);


### PR DESCRIPTION
Due to the `reset: true` option in `setView`, on every zoomend there is a flicker on the maps. This reset option is needed, specially for multi touch devices, because the zoom is computed in a different way. So after every zoom we must reset the internal positions.
This flicker is specially annoying because it happens when the zoom is already (successfully and nicely) done. The reason is an `invalidateAll`, that removes every tile, and loads them again when reset is enabled.

The only way to fix it I have found is to disable temporarily the event 'viewprereset', and restore it later, just in case. I didn't find any other way to disable an event and restore it later. This is done only for the internal calls, like in zoomend.

You can see a simple comparison here (it does not use Sync plugin, just tries to show the efect):
https://jsfiddle.net/La220nrg/1/
The map below flicks. The upper one removes the event, and does not flick.