### PR TITLE
Leaflet 1.1.0

### DIFF
--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -17,7 +17,7 @@
     // with the top right corner of the target map.
     // The values can be less than 0 or greater than 1. It will sync
     // points out of the map.
-    L.Util.offsetHelper = function (ratioRef, ratioTgt) {
+    L.offsetHelper = function (ratioRef, ratioTgt) {
         var or = L.Util.isArray(ratioRef) ? ratioRef : [0.5, 0.5]
         var ot = L.Util.isArray(ratioTgt) ? ratioTgt : [0.5, 0.5]
         return function (center, zoom, refMap, tgtMap) {

--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -9,6 +9,7 @@
         disableViewprereset: true
     };
 
+    L.Sync = function () {};
     // Helper function to compute the offset easily
     // The arguments are relative positions with respect to reference and
     // target maps of the point to sync.
@@ -17,7 +18,7 @@
     // with the top right corner of the target map.
     // The values can be less than 0 or greater than 1. It will sync
     // points out of the map.
-    L.offsetHelper = function (ratioRef, ratioTgt) {
+    L.Sync.offsetHelper = function (ratioRef, ratioTgt) {
         var or = L.Util.isArray(ratioRef) ? ratioRef : [0.5, 0.5]
         var ot = L.Util.isArray(ratioTgt) ? ratioTgt : [0.5, 0.5]
         return function (center, zoom, refMap, tgtMap) {

--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -226,6 +226,15 @@
                         });
                     }
                     return L.Map.prototype._onResize.call(this, event);
+                },
+
+                _stop: function (sync) {
+                    L.Map.prototype._stop.call(this);
+                    if (!sync) {
+                        originalMap._syncMaps.forEach(function (toSync) {
+                            toSync._stop(true);
+                        });
+                    }
                 }
             });
 

--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -31,7 +31,7 @@
     };
 
 
-    L.Map = L.Map.extend({
+    L.Map.include({
         sync: function (map, options) {
             this._initSync();
             options = L.extend({
@@ -70,8 +70,8 @@
             }
 
             // on these events, we should reset the view on every synced map
-            // dragstart and click are due to inertia
-            this.on('resize zoomend dragstart click', this._selfSetView);
+            // dragstart is due to inertia
+            this.on('resize zoomend dragstart', this._selfSetView);
             return this;
         },
 
@@ -114,7 +114,7 @@
 
             if (!this._syncMaps || this._syncMaps.length == 0) {
                 // no more synced maps, so these events are not needed.
-                this.off('resize zoomend dragstart click', this._selfSetView);
+                this.off('resize zoomend dragstart', this._selfSetView);
             }
 
             return this;

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ mapC.sync(mapB);
 You can synchronize not only the centers, but other points, using the option `offsetFn`.
 The parameters send to the function are `(center, zoom, referenceMap, targetMap)`, and it must return the equivalent center to produce your offset. That means, the center to pass to setView.
 
-In most cases, you can use the factory `L.offsetHelper`, that accepts two arrays of two elements each `(ratioRef, ratioTgt)`. The meaning of this array is the relative position -relative to the top left corner and the whole size- in the map container of the point to synchronize. The first value in the array is for the x axis, where 0 is the left side and 1 the right side. The second value in the array is for the y axis, where 0 is the top side, and 1 the bottom side. So `[0, 0]` is the top left corner, `[0, 1]` is the bottom left corner, `[0.5, 1]` is the middle of the bottom side, `[0.5, 0.5]` is the center of the container, `[0.75, 0.25]` is the center of the top right quadrant, and `[2, 0]` is a point out of the container, one 'width' far to the right, in the top line.
+In most cases, you can use the factory `L.Sync.offsetHelper`, that accepts two arrays of two elements each `(ratioRef, ratioTgt)`. The meaning of this array is the relative position -relative to the top left corner and the whole size- in the map container of the point to synchronize. The first value in the array is for the x axis, where 0 is the left side and 1 the right side. The second value in the array is for the y axis, where 0 is the top side, and 1 the bottom side. So `[0, 0]` is the top left corner, `[0, 1]` is the bottom left corner, `[0.5, 1]` is the middle of the bottom side, `[0.5, 0.5]` is the center of the container, `[0.75, 0.25]` is the center of the top right quadrant, and `[2, 0]` is a point out of the container, one 'width' far to the right, in the top line.
 ```
  [0,0]------[0.5,0]------[1,0]     ...       [2,0]
    |                       |
@@ -52,22 +52,22 @@ In most cases, you can use the factory `L.offsetHelper`, that accepts two arrays
 
 ```
 
-For instance `mapB.sync(mapC, {offsetFn: L.offsetHelper([0, 1], [1, 1])});` will sync the bottom left corner `[0, 1]` in the reference map (mapB) with the bottom right corner `[1, 1]` in the target map (mapC).
+For instance `mapB.sync(mapC, {offsetFn: L.Sync.offsetHelper([0, 1], [1, 1])});` will sync the bottom left corner `[0, 1]` in the reference map (mapB) with the bottom right corner `[1, 1]` in the target map (mapC).
 
-As well `mapB.sync(mapA, {offsetFn: L.offsetHelper([0, 0], [1, 0.5])});` will sync the top left corner `[0 ,0]` in mapB with the center of the right side `[1, 0.5]` in mapA.
+As well `mapB.sync(mapA, {offsetFn: L.Sync.offsetHelper([0, 0], [1, 0.5])});` will sync the top left corner `[0 ,0]` in mapB with the center of the right side `[1, 0.5]` in mapA.
 
 If you want the actions to be synced vice-versa, you should use symmetric values (as reference and target are swapped); for instance:
 ```JavaScript
 // place B below A, and show a continuous map
-mapA.sync(mapB, {offsetFn: L.offsetHelper([0, 1], [0, 0])});
-mapB.sync(mapA, {offsetFn: L.offsetHelper([0, 0], [0, 1])});
+mapA.sync(mapB, {offsetFn: L.Sync.offsetHelper([0, 1], [0, 0])});
+mapB.sync(mapA, {offsetFn: L.Sync.offsetHelper([0, 0], [0, 1])});
 ```
 
 The default behaviour is to synchronize the centers, the corresponding offset points are  `[0.5, 0.5], [0.5, 0.5]`.
 
 Have a look at the file [examples/multiple_offset.html](examples/multiple_offset.html) to see how to sync multiple maps with offsets.
 
-If you need a different behaviour not supported by `L.offsetHelper`, create your own function. For instance, if you have a banner on the left side of mapA 100px width that you want to exclude, you can create something like this:
+If you need a different behaviour not supported by `L.Sync.offsetHelper`, create your own function. For instance, if you have a banner on the left side of mapA 100px width that you want to exclude, you can create something like this:
 ```JavaScript
 mapA.sync(mapB, {offsetFn: function (center, zoom, refMap, tgtMap) {
     var pt = refMap.project(center, zoom).add([100, 0]);

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Leaflet.Sync
 ============
 
-Synchronized view of two maps. Tested with Leaflet 1.0.3.
-
-Leaflet.Sync 0.1.2 is the last version supporting Leaflet 1.0.3.
+Synchronized view of two maps. Tested with Leaflet 1.0.3 and 1.1.0.
 
 [More information in original blog post by @turban](http://blog.thematicmapping.org/2013/06/creating-synchronized-view-of-two-maps.html)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ mapC.sync(mapB);
 You can synchronize not only the centers, but other points, using the option `offsetFn`.
 The parameters send to the function are `(center, zoom, referenceMap, targetMap)`, and it must return the equivalent center to produce your offset. That means, the center to pass to setView.
 
-In most cases, you can use the factory `L.Util.offsetHelper`, that accepts two arrays of two elements each `(ratioRef, ratioTgt)`. The meaning of this array is the relative position -relative to the top left corner and the whole size- in the map container of the point to synchronize. The first value in the array is for the x axis, where 0 is the left side and 1 the right side. The second value in the array is for the y axis, where 0 is the top side, and 1 the bottom side. So `[0, 0]` is the top left corner, `[0, 1]` is the bottom left corner, `[0.5, 1]` is the middle of the bottom side, `[0.5, 0.5]` is the center of the container, `[0.75, 0.25]` is the center of the top right quadrant, and `[2, 0]` is a point out of the container, one 'width' far to the right, in the top line.
+In most cases, you can use the factory `L.offsetHelper`, that accepts two arrays of two elements each `(ratioRef, ratioTgt)`. The meaning of this array is the relative position -relative to the top left corner and the whole size- in the map container of the point to synchronize. The first value in the array is for the x axis, where 0 is the left side and 1 the right side. The second value in the array is for the y axis, where 0 is the top side, and 1 the bottom side. So `[0, 0]` is the top left corner, `[0, 1]` is the bottom left corner, `[0.5, 1]` is the middle of the bottom side, `[0.5, 0.5]` is the center of the container, `[0.75, 0.25]` is the center of the top right quadrant, and `[2, 0]` is a point out of the container, one 'width' far to the right, in the top line.
 ```
  [0,0]------[0.5,0]------[1,0]     ...       [2,0]
    |                       |
@@ -52,22 +52,22 @@ In most cases, you can use the factory `L.Util.offsetHelper`, that accepts two a
 
 ```
 
-For instance `mapB.sync(mapC, {offsetFn: L.Util.offsetHelper([0, 1], [1, 1])});` will sync the bottom left corner `[0, 1]` in the reference map (mapB) with the bottom right corner `[1, 1]` in the target map (mapC).
+For instance `mapB.sync(mapC, {offsetFn: L.offsetHelper([0, 1], [1, 1])});` will sync the bottom left corner `[0, 1]` in the reference map (mapB) with the bottom right corner `[1, 1]` in the target map (mapC).
 
-As well `mapB.sync(mapA, {offsetFn: L.Util.offsetHelper([0, 0], [1, 0.5])});` will sync the top left corner `[0 ,0]` in mapB with the center of the right side `[1, 0.5]` in mapA.
+As well `mapB.sync(mapA, {offsetFn: L.offsetHelper([0, 0], [1, 0.5])});` will sync the top left corner `[0 ,0]` in mapB with the center of the right side `[1, 0.5]` in mapA.
 
 If you want the actions to be synced vice-versa, you should use symmetric values (as reference and target are swapped); for instance:
 ```JavaScript
 // place B below A, and show a continuous map
-mapA.sync(mapB, {offsetFn: L.Util.offsetHelper([0, 1], [0, 0])});
-mapB.sync(mapA, {offsetFn: L.Util.offsetHelper([0, 0], [0, 1])});
+mapA.sync(mapB, {offsetFn: L.offsetHelper([0, 1], [0, 0])});
+mapB.sync(mapA, {offsetFn: L.offsetHelper([0, 0], [0, 1])});
 ```
 
 The default behaviour is to synchronize the centers, the corresponding offset points are  `[0.5, 0.5], [0.5, 0.5]`.
 
 Have a look at the file [examples/multiple_offset.html](examples/multiple_offset.html) to see how to sync multiple maps with offsets.
 
-If you need a different behaviour not supported by `L.Util.offsetHelper`, create your own function. For instance, if you have a banner on the left side of mapA 100px width that you want to exclude, you can create something like this:
+If you need a different behaviour not supported by `L.offsetHelper`, create your own function. For instance, if you have a banner on the left side of mapA 100px width that you want to exclude, you can create something like this:
 ```JavaScript
 mapA.sync(mapB, {offsetFn: function (center, zoom, refMap, tgtMap) {
     var pt = refMap.project(center, zoom).add([100, 0]);

--- a/examples/dual.html
+++ b/examples/dual.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js" crossorigin=""></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js" crossorigin=""></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,13 @@
+<html>
+<body>
+  <ul>
+    <li><a href="./dual.html">dual.html</a></li>
+    <li><a href="./multiple.html">multiple.html</a></li>
+    <li><a href="./multiple_offset.html">multiple_offset.html</a></li>
+    <li><a href="./nowrap.html">nowrap.html</a></li>
+    <li><a href="./select_syncs.html">select_syncs.html</a></li>
+    <li><a href="./syncCursor_dual.html">syncCursor_dual.html</a></li>
+    <li><a href="./syncCursor_multiple.html">syncCursor_multiple.html</a></li>
+  </ul>
+</body>
+</html>

--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js" crossorigin=""></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js" crossorigin=""></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/multiple_offset.html
+++ b/examples/multiple_offset.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"
-      integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ=="
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css"
+      integrity="sha512-wcw6ts8Anuw10Mzh9Ytw4pylW8+NAD4ch3lqm9lzAsTxg0GFeJgoAtxuCLREZSC5lUXdVyo/7yfsqFjQ4S+aKw=="
       crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js"
-      integrity="sha512-WXoSHqw/t26DszhdMhOXOkI7qCiv5QWXhH9R7CgvgZMHz1ImlkVQ3uNsiQKu5wwbbxtPzFXd1hK4tzno2VqhpA=="
+    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"
+      integrity="sha512-sIPSXEX730B6EcdQyVPmIGp7f7ZrxIuECnkwYtPpEltG6NqOVtmBNoxHkMamNsAOHLMnDFaUoJYA4PWtzNZDuA=="
       crossorigin=""></script>
 
     <style type="text/css">

--- a/examples/multiple_offset.html
+++ b/examples/multiple_offset.html
@@ -63,8 +63,8 @@
             zoom: 14
         });
 
-        map.sync(mapA, {offsetFn: L.Util.offsetHelper([1, 0], [0, 0])});
-        map.sync(mapB, {offsetFn: L.Util.offsetHelper([1, 1], [0, 1])});
+        map.sync(mapA, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
+        map.sync(mapB, {offsetFn: L.offsetHelper([1, 1], [0, 1])});
 
         var doAll = false;
         var doA = false;
@@ -93,13 +93,13 @@
         // add other links as well
         // or add ?all=1 to the url.
         if (doAll || doA) {
-            mapA.sync(map, {offsetFn: L.Util.offsetHelper([0, 0], [1, 0])});
-            mapA.sync(mapB, {offsetFn: L.Util.offsetHelper([0, 1], [0, 0])});
+            mapA.sync(map, {offsetFn: L.offsetHelper([0, 0], [1, 0])});
+            mapA.sync(mapB, {offsetFn: L.offsetHelper([0, 1], [0, 0])});
         }
 
         if (doAll || doB) {
-            mapB.sync(map, {offsetFn: L.Util.offsetHelper([0, 1], [1, 1])});
-            mapB.sync(mapA, {offsetFn: L.Util.offsetHelper([0, 0], [0, 1])});
+            mapB.sync(map, {offsetFn: L.offsetHelper([0, 1], [1, 1])});
+            mapB.sync(mapA, {offsetFn: L.offsetHelper([0, 0], [0, 1])});
         }
 
     </script>

--- a/examples/multiple_offset.html
+++ b/examples/multiple_offset.html
@@ -63,8 +63,8 @@
             zoom: 14
         });
 
-        map.sync(mapA, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
-        map.sync(mapB, {offsetFn: L.offsetHelper([1, 1], [0, 1])});
+        map.sync(mapA, {offsetFn: L.Sync.offsetHelper([1, 0], [0, 0])});
+        map.sync(mapB, {offsetFn: L.Sync.offsetHelper([1, 1], [0, 1])});
 
         var doAll = false;
         var doA = false;
@@ -93,13 +93,13 @@
         // add other links as well
         // or add ?all=1 to the url.
         if (doAll || doA) {
-            mapA.sync(map, {offsetFn: L.offsetHelper([0, 0], [1, 0])});
-            mapA.sync(mapB, {offsetFn: L.offsetHelper([0, 1], [0, 0])});
+            mapA.sync(map, {offsetFn: L.Sync.offsetHelper([0, 0], [1, 0])});
+            mapA.sync(mapB, {offsetFn: L.Sync.offsetHelper([0, 1], [0, 0])});
         }
 
         if (doAll || doB) {
-            mapB.sync(map, {offsetFn: L.offsetHelper([0, 1], [1, 1])});
-            mapB.sync(mapA, {offsetFn: L.offsetHelper([0, 0], [0, 1])});
+            mapB.sync(map, {offsetFn: L.Sync.offsetHelper([0, 1], [1, 1])});
+            mapB.sync(mapA, {offsetFn: L.Sync.offsetHelper([0, 0], [0, 1])});
         }
 
     </script>

--- a/examples/nowrap.html
+++ b/examples/nowrap.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo (nowrap + maxbounds)</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js" crossorigin=""></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js" crossorigin=""></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/select_syncs.html
+++ b/examples/select_syncs.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening. Select what to sync</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"
-      integrity="sha512-07I2e+7D8p6he1SIM+1twR5TIrhUQn9+I6yjqD53JQjFiMf8EtC93ty0/5vJTZGF8aAocvHYNEDJajGdNx1IsQ=="
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css"
+      integrity="sha512-wcw6ts8Anuw10Mzh9Ytw4pylW8+NAD4ch3lqm9lzAsTxg0GFeJgoAtxuCLREZSC5lUXdVyo/7yfsqFjQ4S+aKw=="
       crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js"
-      integrity="sha512-WXoSHqw/t26DszhdMhOXOkI7qCiv5QWXhH9R7CgvgZMHz1ImlkVQ3uNsiQKu5wwbbxtPzFXd1hK4tzno2VqhpA=="
+    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"
+      integrity="sha512-sIPSXEX730B6EcdQyVPmIGp7f7ZrxIuECnkwYtPpEltG6NqOVtmBNoxHkMamNsAOHLMnDFaUoJYA4PWtzNZDuA=="
       crossorigin=""></script>
 
     <style type="text/css">

--- a/examples/syncCursor_dual.html
+++ b/examples/syncCursor_dual.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js" crossorigin=""></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js" crossorigin=""></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/syncCursor_multiple.html
+++ b/examples/syncCursor_multiple.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js" crossorigin=""></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js" crossorigin=""></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai-leaflet": "0.0.12",
     "eslint": "^2.10.2",
     "eslint-plugin-html": "^1.4.0",
-    "leaflet": "1.0.3",
+    "leaflet": "^1.1.0",
     "mocha": "^2.4.5",
     "mocha-phantomjs-core": "^2.0.1",
     "phantomjs-prebuilt": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai-leaflet": "0.0.12",
     "eslint": "^2.10.2",
     "eslint-plugin-html": "^1.4.0",
-    "leaflet": "^1.1.0",
+    "leaflet": "^1.0.3",
     "mocha": "^2.4.5",
     "mocha-phantomjs-core": "^2.0.1",
     "phantomjs-prebuilt": "^2.1.4",

--- a/test/spec.js
+++ b/test/spec.js
@@ -399,7 +399,7 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
 
-                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
+                a.sync(b, {offsetFn: L.Sync.offsetHelper([1, 0], [0, 0])});
             });
 
             it('has correct inital view', function () {
@@ -454,7 +454,7 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
 
-                a.sync(b, {offsetFn: L.offsetHelper([0, 0], [0, 1])});
+                a.sync(b, {offsetFn: L.Sync.offsetHelper([0, 0], [0, 1])});
             });
 
             it('has correct inital view', function () {
@@ -518,7 +518,7 @@ describe('L.Sync', function () {
                 a.should.have.view([1, 2], 3);
                 b.should.have.view([3, 4], 5);
 
-                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 1])});
+                a.sync(b, {offsetFn: L.Sync.offsetHelper([1, 0], [0, 1])});
                 a.should.have.view([1, 2], 3);
                 b.should.have.view([33.97094, 37.15625], 3);
             });
@@ -535,8 +535,8 @@ describe('L.Sync', function () {
                 a.should.have.view([1, 2], 3);
                 b.should.have.view([0, 0], 5);
 
-                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 1])});
-                b.sync(a, {offsetFn: L.offsetHelper([0, 1], [1, 0])});
+                a.sync(b, {offsetFn: L.Sync.offsetHelper([1, 0], [0, 1])});
+                b.sync(a, {offsetFn: L.Sync.offsetHelper([0, 1], [1, 0])});
                 a._syncMaps.should.have.length(1);
                 Object.keys(a._syncOffsetFns).should.have.length(1);
                 b._syncMaps.should.have.length(1);
@@ -552,10 +552,10 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
                 c = makeMap(c, 'mapC');
-                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
-                b.sync(a, {offsetFn: L.offsetHelper([0, 0], [1, 0])});
-                a.sync(c, {offsetFn: L.offsetHelper([1, 1], [0, 0])});
-                c.sync(a, {offsetFn: L.offsetHelper([0, 0], [1, 1])});
+                a.sync(b, {offsetFn: L.Sync.offsetHelper([1, 0], [0, 0])});
+                b.sync(a, {offsetFn: L.Sync.offsetHelper([0, 0], [1, 0])});
+                a.sync(c, {offsetFn: L.Sync.offsetHelper([1, 1], [0, 0])});
+                c.sync(a, {offsetFn: L.Sync.offsetHelper([0, 0], [1, 1])});
             });
 
             /**
@@ -592,8 +592,8 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
                 c = makeMap(c, 'mapC');
-                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
-                a.sync(c, {offsetFn: L.offsetHelper([2, 0], [0, 0])});
+                a.sync(b, {offsetFn: L.Sync.offsetHelper([1, 0], [0, 0])});
+                a.sync(c, {offsetFn: L.Sync.offsetHelper([2, 0], [0, 0])});
             });
 
             it('syncs', function () {

--- a/test/spec.js
+++ b/test/spec.js
@@ -399,7 +399,7 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
 
-                a.sync(b, {offsetFn: L.Util.offsetHelper([1, 0], [0, 0])});
+                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
             });
 
             it('has correct inital view', function () {
@@ -454,7 +454,7 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
 
-                a.sync(b, {offsetFn: L.Util.offsetHelper([0, 0], [0, 1])});
+                a.sync(b, {offsetFn: L.offsetHelper([0, 0], [0, 1])});
             });
 
             it('has correct inital view', function () {
@@ -518,7 +518,7 @@ describe('L.Sync', function () {
                 a.should.have.view([1, 2], 3);
                 b.should.have.view([3, 4], 5);
 
-                a.sync(b, {offsetFn: L.Util.offsetHelper([1, 0], [0, 1])});
+                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 1])});
                 a.should.have.view([1, 2], 3);
                 b.should.have.view([33.97094, 37.15625], 3);
             });
@@ -535,8 +535,8 @@ describe('L.Sync', function () {
                 a.should.have.view([1, 2], 3);
                 b.should.have.view([0, 0], 5);
 
-                a.sync(b, {offsetFn: L.Util.offsetHelper([1, 0], [0, 1])});
-                b.sync(a, {offsetFn: L.Util.offsetHelper([0, 1], [1, 0])});
+                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 1])});
+                b.sync(a, {offsetFn: L.offsetHelper([0, 1], [1, 0])});
                 a._syncMaps.should.have.length(1);
                 Object.keys(a._syncOffsetFns).should.have.length(1);
                 b._syncMaps.should.have.length(1);
@@ -552,10 +552,10 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
                 c = makeMap(c, 'mapC');
-                a.sync(b, {offsetFn: L.Util.offsetHelper([1, 0], [0, 0])});
-                b.sync(a, {offsetFn: L.Util.offsetHelper([0, 0], [1, 0])});
-                a.sync(c, {offsetFn: L.Util.offsetHelper([1, 1], [0, 0])});
-                c.sync(a, {offsetFn: L.Util.offsetHelper([0, 0], [1, 1])});
+                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
+                b.sync(a, {offsetFn: L.offsetHelper([0, 0], [1, 0])});
+                a.sync(c, {offsetFn: L.offsetHelper([1, 1], [0, 0])});
+                c.sync(a, {offsetFn: L.offsetHelper([0, 0], [1, 1])});
             });
 
             /**
@@ -592,8 +592,8 @@ describe('L.Sync', function () {
                 a = makeMap(a, 'mapA');
                 b = makeMap(b, 'mapB');
                 c = makeMap(c, 'mapC');
-                a.sync(b, {offsetFn: L.Util.offsetHelper([1, 0], [0, 0])});
-                a.sync(c, {offsetFn: L.Util.offsetHelper([2, 0], [0, 0])});
+                a.sync(b, {offsetFn: L.offsetHelper([1, 0], [0, 0])});
+                a.sync(c, {offsetFn: L.offsetHelper([2, 0], [0, 0])});
             });
 
             it('syncs', function () {


### PR DESCRIPTION
Migration to leaflet 1.1.0. :
- [x] ~~Change dependency in `package.json`?~~
- [x] Use `include` instead of `extend` with `L.Map`. Was not working in 1.1.0 (see https://github.com/Leaflet/Leaflet/blob/master/PLUGIN-GUIDE.md#plugin-api)
- [x] ~~Remove `click` event call, due to fix https://github.com/Leaflet/Leaflet/pull/5378~~
- [x] Grrrr.	Rename `L.Util.offsetHelper` into `L.Sync.offsetHelper`. I was not able to extend `L.Util`
- [x] BTW, fix shake after drag (with inertia) and zoom in Firefox (also in 1.0.3)
- [x] Use leaflet 1.1.0 in examples

Tip to see the different version in a map: The minus character in the zoom control  https://github.com/Leaflet/Leaflet/pull/5501