### PR TITLE
Leaflet 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Leaflet.Sync
 ============
 
-Synchronized view of two maps. Tested with Leaflet 1.0.3 and 1.1.0.
+Synchronized view of two maps. Tested with Leaflet 1.0.3, 1.1.0 and 1.2.0.
 
 [More information in original blog post by @turban](http://blog.thematicmapping.org/2013/06/creating-synchronized-view-of-two-maps.html)
 

--- a/examples/dual.html
+++ b/examples/dual.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js" crossorigin=""></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js" crossorigin=""></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/multiple_offset.html
+++ b/examples/multiple_offset.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/nowrap.html
+++ b/examples/nowrap.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo (nowrap + maxbounds)</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/select_syncs.html
+++ b/examples/select_syncs.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening. Select what to sync</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/syncCursor_dual.html
+++ b/examples/syncCursor_dual.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }

--- a/examples/syncCursor_multiple.html
+++ b/examples/syncCursor_multiple.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Leaflet Sync Demo - with three maps listening</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
 
     <style type="text/css">
         html, body { width: 100%; height: 100%; margin: 0; }


### PR DESCRIPTION
It is compatible with [Leaflet 1.2.0](http://leafletjs.com/2017/08/08/leaflet-1.2.0.html) (released 2017-08-08) without any change. I just tested it, updated README and examples.
With this PR travis' tests will be executed with the new Leaflet, and it should work ;)

So not a hurry at all to make a release.