### PR TITLE
offsetFn with zoom

### DIFF
--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -50,6 +50,16 @@
                 }
             }, options);
 
+            var offsetOriginalFn = options.offsetFn;
+            function wrapFn (center, zoom, refMap, targetMap) {
+                var result = offsetOriginalFn(center, zoom, refMap, targetMap);
+                if ('center' in result) {
+                    return result;
+                }
+                return {center: result, zoom: zoom};
+            }
+            options.offsetFn = wrapFn;
+
             // prevent double-syncing the map:
             if (this._syncMaps.indexOf(map) === -1) {
                 this._syncMaps.push(map);
@@ -57,9 +67,8 @@
             }
 
             if (!options.noInitialSync) {
-                map.setView(
-                    options.offsetFn(this.getCenter(), this.getZoom(), this, map),
-                    this.getZoom(), NO_ANIMATION);
+                var centerZoom = options.offsetFn(this.getCenter(), this.getZoom(), this, map);
+                map.setView(centerZoom.center, centerZoom.zoom, NO_ANIMATION);
             }
             if (options.syncCursor) {
                 if (typeof map.cursor === 'undefined') {
@@ -168,6 +177,16 @@
             this._syncDragend = true;
         },
 
+        _zoomFactorTo: function (syncedMap) {
+            var zoom = this.getZoom();
+            var toSyncZoom = syncedMap.getZoom();
+            if (zoom == toSyncZoom) {
+                return 1;
+            }
+            var zoomDiff = zoom - toSyncZoom;
+            var zoomFactor = Math.pow((zoomDiff > 0) ? .5 : 2, Math.abs(zoomDiff));
+            return zoomFactor;
+        },
 
         // overload methods on originalMap to replay interactions on _syncMaps;
         _initSync: function () {
@@ -211,9 +230,8 @@
                     if (!sync) {
                         originalMap._syncMaps.forEach(function (toSync) {
                             sandwich(toSync, function (obj) {
-                                return toSync.setView(
-                                    originalMap._syncOffsetFns[L.Util.stamp(toSync)](center, zoom, originalMap, toSync),
-                                    zoom, options, true);
+                                var centerZoom = originalMap._syncOffsetFns[L.Util.stamp(toSync)](center, zoom, originalMap, toSync);
+                                return toSync.setView(centerZoom.center, centerZoom.zoom, options, true);
                             });
                         });
                     }
@@ -224,11 +242,16 @@
                 panBy: function (offset, options, sync) {
                     if (!sync) {
                         originalMap._syncMaps.forEach(function (toSync) {
-                            toSync.panBy(offset, options, true);
+                            var zoomFactor = originalMap._zoomFactorTo(toSync);
+                            var newOffset = !Array.isArray(offset) ?
+                                offset.multiplyBy(zoomFactor) :
+                                offset.map(function (o) {return o*zoomFactor;});
+                            toSync.panBy(newOffset, options, true);
                         });
                     }
                     return L.Map.prototype.panBy.call(this, offset, options);
                 },
+
 
                 _onResize: function (event, sync) {
                     if (!sync) {
@@ -253,12 +276,15 @@
                 L.Draggable.prototype._updatePosition.call(this);
                 var self = this;
                 originalMap._syncMaps.forEach(function (toSync) {
-                    L.DomUtil.setPosition(toSync.dragging._draggable._element, self._newPos);
+                    var zoomFactor = originalMap._zoomFactorTo(toSync);
+                    var newPos = self._newPos.multiplyBy(zoomFactor);
+                    L.DomUtil.setPosition(toSync.dragging._draggable._element, newPos);
                     toSync.eachLayer(function (layer) {
                         if (layer._google !== undefined) {
                             var offsetFn = originalMap._syncOffsetFns[L.Util.stamp(toSync)];
-                            var center = offsetFn(originalMap.getCenter(), originalMap.getZoom(), originalMap, toSync);
-                            layer._google.setCenter(center);
+                            var centerZoom = offsetFn(originalMap.getCenter(), originalMap.getZoom(), originalMap, toSync);
+                            layer._google.setCenter(centerZoom.center);
+                            layer._google.setZoom(centerZoom.zoom);
                         }
                     });
                     toSync.fire('move');

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,6 +4,7 @@
         <li><a href="./dual.html">dual.html</a></li>
         <li><a href="./multiple.html">multiple.html</a></li>
         <li><a href="./multiple_offset.html">multiple_offset.html</a></li>
+        <li><a href="./multiple_offset_zoom.html">multiple_offset_zoom.html</a></li>
         <li><a href="./nowrap.html">nowrap.html</a></li>
         <li><a href="./select_syncs.html">select_syncs.html</a></li>
         <li><a href="./syncCursor_dual.html">syncCursor_dual.html</a></li>

--- a/examples/multiple_offset_zoom.html
+++ b/examples/multiple_offset_zoom.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Leaflet Sync Demo - with three maps listening</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet-src.js" crossorigin=""></script>
+
+    <style type="text/css">
+        html, body { width: 100%; height: 100%; margin: 0; }
+        #map, #container { width: 49.5%; height: 100%; }
+        #map { float: left; }
+        #container { float: right; }
+        #container .map { width: 100%; height: 50%; }
+    </style>
+</head>
+
+<body>
+    <div id="map"></div>
+    <div id="container">
+        <div id="mapA" class="map"></div>
+        <div id="mapB" class="map"></div>
+    </div>
+
+    <script src="../L.Map.Sync.js"></script>
+
+    <script type="text/javascript">
+        var center = [52.517, 13.388];
+
+        var options = {
+            attribution: '<a href="https://openstreetmap.org/copyright">&copy; OpenStreetmap and Contributors</a>',
+            subdomains: 'abc',
+            minZoom: 0,
+            maxZoom: 20
+        };
+
+        var osm = L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', options);
+        var osmfr = L.tileLayer('https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', options);
+        var osmbw = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', options);
+
+
+        var map = L.map('map', {
+            layers: [osm],
+            center: center,
+            zoom: 7
+        });
+
+        var mapA = L.map('mapA', {
+            layers: [osmfr],
+            center: center,
+            zoom: 8,
+            zoomControl: false
+        });
+        var mapB = L.map('mapB', {
+            layers: [osmbw],
+            center: center,
+            zoom: 6,
+            zoomControl: false
+        });
+
+        function maker (z) {
+            return {
+                offsetFn: function (center, zoom, rm, tm) {
+                    return {center: center, zoom: zoom + z}; 
+                }
+            };
+        }
+
+        map.sync(mapA, maker(+1));
+        map.sync(mapB, maker(-1));
+
+        var doAll = false;
+        var doA = false;
+        var doB = false;
+
+        var p = location.search;
+        if (p != '') {
+            var params = p.substring(1).split('&');
+            for (var i = 0; i < params.length; i++) {
+                var param = params[i].split('=');
+                switch (param[0]) {
+                case 'all':
+                    doAll = parseInt(param[1]);
+                    break;
+                case 'a':
+                    doA = parseInt(param[1]);
+                    break;
+                case 'b':
+                    doB = parseInt(param[1]);
+                    break;
+                }
+            }
+        }
+
+        // If you want interaction with mapA|B to be synchronized on map,
+        // add other links as well.
+        // or add ?all=1 to the url.
+        if (doAll || doA) {
+            mapA.sync(map, maker(-1));
+            mapA.sync(mapB, maker(-2));
+        }
+
+        if (doAll || doB) {
+            mapB.sync(map, maker(+1));
+            mapB.sync(mapA, maker(+2));
+        }
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
**WIP**
In response to https://github.com/jieter/Leaflet.Sync/issues/59 and https://github.com/jieter/Leaflet.Sync/issues/41 (thanks for the code suggestions; many are included here), this PR lets the user to return an object like `{center, zoom}` in the callback `offsetFn`.

To not break backwards compatibility, there is a wrapper function to add the zoom if only the center is returned. So both things can be returned in `offsetFn`: just the center, or an object with `center` and `zoom`.

This is WIP. Still some tests and documentation to be added.

There is one example, examples/multiple_offset_zoom.html, in case you want to have a look.

There is a problem detected. In case of a.sync(b) and b.sync(a) where the zoom changes are not properly correlated, it enters in an infinite loop. Leaflet detects a zoom change, and fires an update in the other.