### PR TITLE
Fix examples

### DIFF
--- a/examples/dual.html
+++ b/examples/dual.html
@@ -24,12 +24,12 @@
 
         var layer1 = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
             maxZoom: 17,
-            attribution: 'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+            attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
         });
 
-        var layer2 = L.tileLayer('https://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png', {
-            maxZoom: 18,
-            attribution: 'Tiles courtesy of <a href="http://openstreetmap.se/" target="_blank">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        var layer2 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 17,
+            attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
         });
 
         var map1 = L.map('map1', {

--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -29,17 +29,17 @@
 
         var stamenOptions = {
             attribution:
-                'Map tiles by <a href="http://stamen.com">Stamen Design</a>, ' +
-                '<a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; ' +
+                'Map tiles by <a href="https://stamen.com">Stamen Design</a>, ' +
+                '<a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; ' +
                 'Map data OpenStreetmap',
             subdomains: 'abcd',
             minZoom: 0,
             maxZoom: 20
         };
 
-        var toner = L.tileLayer('http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png', stamenOptions);
-        var tonerLite = L.tileLayer('http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png', stamenOptions);
-        var watercolor = L.tileLayer('http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg', stamenOptions);
+        var toner = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', stamenOptions);
+        var tonerLite = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', stamenOptions);
+        var watercolor = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg', stamenOptions);
 
         var map = L.map('map', {
             layers: [toner],

--- a/examples/multiple_offset.html
+++ b/examples/multiple_offset.html
@@ -28,15 +28,15 @@
         var center = [52.517, 13.388];
 
         var options = {
-            attribution: '<a href="http://openstreetmap.org/copyright">&copy; OpenStreetmap and Contributors</a>',
+            attribution: '<a href="https://openstreetmap.org/copyright">&copy; OpenStreetmap and Contributors</a>',
             subdomains: 'abc',
             minZoom: 0,
             maxZoom: 20
         };
 
-        var osm = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', options);
-        var osmfr = L.tileLayer('http://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', options);
-        var osmbw = L.tileLayer('http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png', options);
+        var osm = L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', options);
+        var osmfr = L.tileLayer('https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', options);
+        var osmbw = L.tileLayer('https://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png', options);
 
         var mapA = L.map('mapA', {
             layers: [osmfr],

--- a/examples/nowrap.html
+++ b/examples/nowrap.html
@@ -33,15 +33,15 @@
             zoomControl: false
         }).setView(center, zoom);
 
-        L.tileLayer('http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png', {
+        L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', {
             subdomains: 'abcd',
             minZoom: 0,
             maxZoom: 20,
             noWrap: true
         }).addTo(map1);
 
-        L.tileLayer('http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png', {
-            attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
+            attribution: 'Map tiles by <a href="https://stamen.com">Stamen Design</a>, <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
             subdomains: 'abcd',
             minZoom: 0,
             maxZoom: 20,

--- a/examples/select_syncs.html
+++ b/examples/select_syncs.html
@@ -38,7 +38,7 @@
 
         var options = {
             attribution:
-                '<a href="http://openstreetmap.org/copyright">' +
+                '<a href="https://openstreetmap.org/copyright">' +
                 '&copy; OpenStreetmap and Contributors</a>',
             subdomains: 'abc',
             minZoom: 0,

--- a/examples/syncCursor_dual.html
+++ b/examples/syncCursor_dual.html
@@ -22,9 +22,9 @@
     <script type="text/javascript">
         var center = [59.336, 5.967];
 
-        var layer1 = L.tileLayer('http://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norges_grunnkart&zoom={z}&x={x}&y={y}');
+        var layer1 = L.tileLayer('https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norges_grunnkart&zoom={z}&x={x}&y={y}');
 
-        var layer2 = L.tileLayer('http://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2&zoom={z}&x={x}&y={y}', {
+        var layer2 = L.tileLayer('https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo4&zoom={z}&x={x}&y={y}', {
             attribution: '© Kartverket'
         });
 

--- a/examples/syncCursor_multiple.html
+++ b/examples/syncCursor_multiple.html
@@ -29,17 +29,17 @@
 
         var stamenOptions = {
             attribution:
-                'Map tiles by <a href="http://stamen.com">Stamen Design</a>, ' +
-                '<a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; ' +
+                'Map tiles by <a href="https://stamen.com">Stamen Design</a>, ' +
+                '<a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; ' +
                 'Map data OpenStreetmap',
             subdomains: 'abcd',
             minZoom: 0,
             maxZoom: 20
         };
 
-        var toner = L.tileLayer('http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png', stamenOptions);
-        var tonerLite = L.tileLayer('http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png', stamenOptions);
-        var watercolor = L.tileLayer('http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg', stamenOptions);
+        var toner = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', stamenOptions);
+        var tonerLite = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', stamenOptions);
+        var watercolor = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg', stamenOptions);
 
         var map = L.map('map', {
             layers: [toner],


### PR DESCRIPTION
Fixes the examples by

- Using HTTPS for all links and resources that support it
- Using HTTPS for all Stamen resources (see https://github.com/stamen/maps.stamen.com/issues/67)
- Using the new topo layer for the Statkart map (see https://github.com/osmandapp/Osmand/issues/5818)

closes #63 